### PR TITLE
use latest available bun version. Copy bun from official image directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
-FROM debian:stable-slim as get
-
-WORKDIR /bun
-
-RUN apt-get update
-RUN apt-get install curl unzip -y
-RUN curl --fail --location --progress-bar --output "/bun/bun.zip" "https://github.com/Jarred-Sumner/bun/releases/download/bun-v0.1.1/bun-linux-x64.zip"
-RUN unzip -d /bun -q -o "/bun/bun.zip"
-RUN mv /bun/bun-linux-x64/bun /usr/local/bin/bun
-RUN chmod 777 /usr/local/bin/bun
-
 FROM debian:stable-slim
-COPY --from=get /usr/local/bin/bun /bin/bun
+COPY --from=oven/bun /usr/local/bin/bun /bin/bun
 WORKDIR /app
 ADD http.js /app/http.js
 


### PR DESCRIPTION
Copy `bun` directly from `oven/bun` image instead of installing it then copying it. Also use `latest` version of bun.