### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ WORKDIR /bun
 
 RUN apt-get update
 RUN apt-get install curl unzip -y
-RUN curl --fail --location --progress-bar --output "/bun/bun.zip" "https://github.com/Jarred-Sumner/bun/releases/download/bun-v0.1.1/bun-linux-x64.zip"
+RUN curl --fail --location --progress-bar --output "/bun/bun.zip" "https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip"
 RUN unzip -d /bun -q -o "/bun/bun.zip"
 RUN mv /bun/bun-linux-x64/bun /usr/local/bin/bun
 RUN chmod 777 /usr/local/bin/bun
 
 FROM debian:stable-slim
 COPY --from=get /usr/local/bin/bun /bin/bun
+RUN ln -s /bin/bun /bin/bunx && chmod 777 /bin/bunx
 WORKDIR /app
 ADD http.js /app/http.js
 


### PR DESCRIPTION
- Uses latest version of Bun (should the version number be in the URL?)
- Symlinks `bunx` so that `bunx` works

An alternative option is using Bun's `oven/bun` docker image and copying from that